### PR TITLE
fix function name in apis

### DIFF
--- a/apis/apis/meeting_schedule.json
+++ b/apis/apis/meeting_schedule.json
@@ -102,6 +102,6 @@
   ],
   "required": ["Name", "UserName", "Day", "StartTimeHour", "EndTimeHour"],
   "db": "schedule",
-  "function": "schedule_meeting",
+  "function": "meeting_schedule",
   "returns_count": false
 }


### PR DESCRIPTION
Fix name of the function for `meeting_schedule` task in the corresponding api json file.